### PR TITLE
Use Ubuntu 24.04 GitHub Runner

### DIFF
--- a/.github/workflows/build-game.yml
+++ b/.github/workflows/build-game.yml
@@ -6,7 +6,7 @@ on: [ push, pull_request ]
 jobs:
   build-gcc:
     name: Linux build on Ubuntu
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
At the moment the Linux build fails.

>  Linux build on Ubuntu
This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101

This is a try to upgrade to a new Ubuntu runner version